### PR TITLE
permissions fix

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,13 +1,88 @@
 turnkey-roundup-18.0 (1) turnkey; urgency=low
 
   * Update roundup to 2.3.0.
+    [Anton Pyrogovskyi <anton@turnkeylinux.org>]
 
-  * Updated all relevant Debian packages to Bookworm/12 versions
+  * Confconsole: bugfix broken DNS-01 Let's Encrypt challenge- closes #1876 &
+    #1895.
+    [Jeremy Davis <jeremy@turnkeylinux.org>]
 
-  * Note: Please refer to turnkey-core's 18.0 changelog for changes common to all
-    appliances. Here we only describe changes specific to this appliance.
+  * Ensure hashfile includes URL to public key - closes #1864.
 
- -- Anton Pyrogovskyi <anton@turnkeylinux.org>  Mon, 25 Mar 2024 18:22:12 +0100
+  * Include webmin-logviewer module by default - closes #1866.
+
+  * Upgraded base distribution to Debian 12.x/Bookworm.
+
+  * Configuration console (confconsole):
+    - Support for DNS-01 Let's Encrypt challenges.
+      [ Oleh Dmytrychenko <dmytrychenko.oleh@gmail.com> github: @NitrogenUA ]
+    - Support for getting Let's Encrypt cert via IPv6 - closes #1785.
+    - Refactor network interface code to ensure that it works as expected and
+      supports more possible network config (e.g. hotplug interfaces & wifi).
+    - Show error message rather than stacktrace when window resized to
+      incompatable resolution - closes  #1609.
+      [ Stefan Davis <stefan@turnkeylinux.org> ]
+    - Bugfix exception when quitting configuration of mail relay.
+      [ Oleh Dmytrychenko <dmytrychenko.oleh@gmail.com> github: @NitrogenUA ]
+    - Improve code quality: implement typing, fstrings and make (mostly) PEP8
+      compliant.
+      [Stefan Davis <stefan@turnkeylinux.org> & Jeremy Davis
+
+  * Firstboot Initialization (inithooks):
+    - Refactor start up (now hooks into getty process, rather than having it's
+      own service).
+      [ Stefan Davis <stefan@turnkeylinux.org> ]
+    - Refactor firstboot.d/01ipconfig (and 09hostname) to ensure that hostname
+      is included in dhcp info when set via inithooks.
+    - Package turnkey-make-ssl-cert script (from common overlay - now packaged
+      as turnkey-ssl). Refactor relevant scripts to leverage turnkey-ssl.
+    - Refactor run script - use bashisms and general tidying.
+    - Show blacklisted password characters more nicely.
+    - Misc packaging changes/improvements.
+    - Support returning output from MySQL - i.e. support 'SELECT'. (Only
+      applies to apps that include MySQL/MariaDB).
+
+  * Web management console (webmin):
+    - Upgraded webmin to v2.105.
+    - Replace webmin-shell with webmin-xterm module by default - closes #1904.
+    - Removed stunnel reverse proxy (Webmin hosted directly now).
+    - Ensure that Webmin uses HTTPS with default cert
+      (/etc/ssl/private/cert.pem).
+    - Disabled Webmin Let's Encrypt (for now).
+
+  * Web shell (shellinabox):
+    - Completely removed in v18.0 (Webmin now has a proper interactive shell).
+    - Note: previous v18.0 releases did not include webmin-xterm pkg - see
+      above webmin note &/or #1904.
+
+  * Backup (tklbam):
+    - Ported dependencies to Debian Bookworm; otherwise unchanged.
+
+  * Security hardening & improvements:
+    - Generate and use new TurnKey Bookworm keys.
+    - Automate (and require) default pinning for packages from Debian
+      backports. Also support non-free backports.
+
+  * IPv6 support:
+    - Adminer (only on LAMP based apps) listen on IPv6.
+    - Nginx/NodeJS (NodeJS based apps only) listen on IPv6.
+
+  * Misc bugfixes & feature implementations:
+    - Remove rsyslog package (systemd journal now all that's needed).
+    - Include zstd compression support.
+    - Enable new non-free-firmware apt repo by default.
+    - Improve turnkey-artisan so that it works reliably in cron jobs (only
+      Laravel based LAMP apps).
+
+  * Set mod_evasive log location - makes debugging easier.
+    [ Jeremy Davis <jeremy@turnkeylinux.org> ]
+
+  * Include and enable mod_evasive and mod_security2 by default in Apache.
+    [ Stefan Davis <Stefan@turnkeylinux.org> ]
+
+  * Use MariaDB (MySQL replacement) v10.11.3 (from debian repos).
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Wed, 03 Apr 2024 22:44:33 +0000
 
 turnkey-roundup-17.1 (1) turnkey; urgency=low
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,14 @@
+turnkey-roundup-18.0 (1) turnkey; urgency=low
+
+  * Update roundup to 2.3.0.
+
+  * Updated all relevant Debian packages to Bookworm/12 versions
+
+  * Note: Please refer to turnkey-core's 18.0 changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Anton Pyrogovskyi <anton@turnkeylinux.org>  Mon, 25 Mar 2024 18:22:12 +0100
+
 turnkey-roundup-17.1 (1) turnkey; urgency=low
 
   * Updated all Debian packages to latest.

--- a/conf.d/main
+++ b/conf.d/main
@@ -8,7 +8,7 @@ DB_PASS=$(mcookie)
 RT_TRACKER=/var/lib/roundup/tracker
 RT_TEMPLATE=classic
 RT_BACKEND=mysql
-RT_VER=2.3.0
+RT_VER=$(gh_releases roundup-tracker/roundup | grep -v 'git\|alpha\|beta\|b' | sort -V | tail -1)
 RT_CONF=/etc/roundup/tracker-config.ini
 RT_HOME="/home/$USER"
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -28,6 +28,9 @@ as_user python3 -m pip install mysqlclient roundup pytz
 DOCS="$RT_HOME/versions/$RT_VER/share/doc/roundup/html"
 chmod o+x $DOCS{,/_{images,sources,static}}
 
+# allow Apache access to venv dir listing
+chmod o+x $RT_HOME{,/versions{,/$RT_VER}}
+
 a2enmod wsgi
 a2enmod rewrite
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -10,36 +10,23 @@ RT_TEMPLATE=classic
 RT_BACKEND=mysql
 RT_VER=2.3.0
 RT_CONF=/etc/roundup/tracker-config.ini
-RT_LOCAL=/home/$USER/.local
+RT_HOME="/home/$USER"
 
-PY_V=$(python3 --version | sed "s|^.* \(3\.[0-9]\+\).*|\1|")
+as_user() { su - "$USER" -c "$*"; }
 
-adduser --disabled-login --gecos 'roundup user' $USER
+adduser --disabled-login --gecos 'roundup user' --shell /bin/bash $USER
 
-roundup-install.sh "$RT_VER"
+as_user mkdir versions
+as_user python3 -m venv "versions/$RT_VER"
 
-#  set home access perms
-chmod -R 0775 ${RT_LOCAL}
-chmod -R 0774 ${RT_LOCAL}/share
+as_user echo ". versions/$RT_VER/bin/activate" '>' .bashrc.d/roundup-venv
+as_user chmod +x .bashrc.d/roundup-venv
+
+as_user python3 -m pip install mysqlclient roundup pytz
 
 # allow Apache access to docs - requires search perms (x on directory)
-# for full path
-DOCS=$RT_LOCAL/share/doc/roundup/html
-SUB_DIRS="_images _sources _static"
-for dir in $SUB_DIRS; do
-    chmod o+x $DOCS/$dir
-done
-dir=$DOCS
-while [ "$dir" != "$(dirname $RT_LOCAL)" ]; do
-    chmod o+x $dir
-    dir=$(dirname $dir)
-done
-
-
-# innodb workaround (Incorrect information in file: './roundup/schema.frm'")
-service mysql start
-service mysql stop
-rm /var/lib/mysql/ib*
+DOCS="$RT_HOME/versions/$RT_VER/share/doc/roundup/html"
+chmod o+x $DOCS{,/_{images,sources,static}}
 
 a2enmod wsgi
 a2enmod rewrite
@@ -56,10 +43,10 @@ mkdir -p $RT_TRACKER
 mkdir /etc/roundup
 chown -R roundup:roundup $RT_TRACKER
 OPTIONS="admin_email=admin,dispatcher_email=admin,tracker_web=https://www.example.com/,mail_domain=example.com,mail_host=localhost,rdbms_password=$DB_PASS"
-su - $USER -c "roundup-admin -i $RT_TRACKER install $RT_TEMPLATE $RT_BACKEND $OPTIONS"
-su - $USER -c "roundup-admin -i $RT_TRACKER initialise $ADMIN_PASS"
+as_user "roundup-admin -i $RT_TRACKER install $RT_TEMPLATE $RT_BACKEND $OPTIONS"
+as_user "roundup-admin -i $RT_TRACKER initialise $ADMIN_PASS"
 echo "tracker = $RT_TRACKER" >> /etc/roundup/roundup-server.ini
-#chown -R www-data:www-data $RT_TRACKER/db
+chown -R www-data:www-data $RT_TRACKER/db
 
 # configure mod_wsgi
 cat > $RT_TRACKER/wsgi.py <<EOF

--- a/conf.d/main
+++ b/conf.d/main
@@ -8,7 +8,7 @@ DB_PASS=$(mcookie)
 RT_TRACKER=/var/lib/roundup/tracker
 RT_TEMPLATE=classic
 RT_BACKEND=mysql
-RT_VER=2.1.0
+RT_VER=2.3.0
 RT_CONF=/etc/roundup/tracker-config.ini
 RT_LOCAL=/home/$USER/.local
 

--- a/overlay/etc/apache2/sites-available/roundup.conf
+++ b/overlay/etc/apache2/sites-available/roundup.conf
@@ -1,14 +1,14 @@
 ServerName localhost
 
-Alias /docs /home/roundup/.local/share/doc/roundup/html
-
+Alias /docs /home/roundup/versions/2.3.0/share/doc/roundup/html
 Alias /robots.txt /var/www/static/robots.txt
 Alias /favicon.ico /var/www/static/favicon.ico
 
 AliasMatch ^/@@file/(.*) /var/lib/roundup/tracker/html/$1
 
 WSGIScriptAlias / /var/lib/roundup/tracker/wsgi.py
-WSGIPythonPath /home/roundup/.local/lib/python3.9/site-packages
+WSGIPythonHome /home/roundup/versions/2.3.0
+WSGIPythonPath /home/roundup/versions/2.3.0/lib/python3.11/site-packages
 
 <VirtualHost *:80>
     UseCanonicalName Off
@@ -34,7 +34,7 @@ WSGIPythonPath /home/roundup/.local/lib/python3.9/site-packages
     Options None
 </Directory>
 
-<Directory /home/roundup/.local/share/doc/roundup/html>
+<Directory /home/roundup/versions/2.3.0/share/doc/roundup/html>
     Require all granted
     AllowOverride None
     Options None

--- a/overlay/usr/local/bin/roundup-install.sh
+++ b/overlay/usr/local/bin/roundup-install.sh
@@ -23,7 +23,7 @@ EOF
 }
 
 fatal() {
-    echo "error: $@" >&2
+    echo "error: $*" >&2
     usage
     exit 1
 }
@@ -100,10 +100,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ "${#POSITIONAL[@]}" < 1 ]]; then
+if [[ "${#POSITIONAL[@]}" -lt 1 ]]; then
     fatal "version is required"
-elif [[ "${#POSITIONAL[@]}" > 1 ]]; then
-    fatal "unknown extra args provided: ${POSITIONAL[@]:1}"
+elif [[ "${#POSITIONAL[@]}" -gt 1 ]]; then
+    fatal "unknown extra args provided: ${POSITIONAL[*]:1}"
 fi
 VER="${POSITIONAL[0]}"
 
@@ -114,7 +114,7 @@ if ! is_cached "$VER"; then
     else
         download_ver "$VER"
     fi
-elif [ "$DOWNOAD" == 'y' ]; then
+elif [ "$DOWNLOAD" == 'y' ]; then
     download_ver "$VER"
 fi
 

--- a/overlay/usr/local/bin/roundup-install.sh
+++ b/overlay/usr/local/bin/roundup-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 usage() {
     cat <<EOF

--- a/plan/main
+++ b/plan/main
@@ -5,11 +5,10 @@ apache2
 libapache2-mod-wsgi-py3
 webmin-apache
 
-/* pip3 and deps  */
 python3-pip
-python3-setuptools
-python3-wheel
 python3-dev
+python3-venv
 
-python3-mysqldb             /* roundup MySQL connector */
-python3-tz                  /* Full timezone support */
+pkg-config
+build-essential
+default-libmysqlclient-dev


### PR DESCRIPTION
- overlay: use "base -e" in install script
- overlay: install script shellcheck lints, fix typo
- conf.d: bump roundup version to 2.3.0
- install via pip as upstream suggests
- update changelog
- Get latest version dynamically
- Update changelog to include common changes
- allow apache to access venv parent directories
